### PR TITLE
Patch for conditional rule parser.

### DIFF
--- a/src/Javascript/RuleParser.php
+++ b/src/Javascript/RuleParser.php
@@ -2,6 +2,7 @@
 
 namespace Proengsoft\JsValidation\Javascript;
 
+use Illuminate\Validation\ValidationRuleParser;
 use Proengsoft\JsValidation\Support\RuleListTrait;
 use Proengsoft\JsValidation\Support\DelegatedValidator;
 use Proengsoft\JsValidation\Support\UseDelegatedValidatorTrait;
@@ -93,8 +94,8 @@ class RuleParser
     {
         foreach ((array) $attribute as $key) {
             $current = isset($this->conditional[$key]) ? $this->conditional[$key] : [];
-            $merge = head($this->validator->explodeRules((array) $rules));
-            $this->conditional[$key] = array_merge($current, $merge);
+            $merge = (new ValidationRuleParser([]))->explode((array) $rules);
+            $this->conditional[$key] = array_merge($current, head($merge->rules));
         }
     }
 


### PR DESCRIPTION
Hi, I made some ugly patch for live conditional rules. (sometimes method) 
Before this path sometimes method throws exception 

> Method [explodeRules] does not exist.